### PR TITLE
Update hip_obj_gen.mcin

### DIFF
--- a/samples/2_Cookbook/16_assembly_to_executable/hip_obj_gen.mcin
+++ b/samples/2_Cookbook/16_assembly_to_executable/hip_obj_gen.mcin
@@ -12,17 +12,9 @@
 #
 # Note: log 2 of 4096 is 12.
 #
-  .protected __hip_gpubin_handle_
-  .type __hip_gpubin_handle_,@object
-  .section .hip_gpubin_handle,"aw"
-  .globl __hip_gpubin_handle_
-  .p2align 12
-__hip_gpubin_handle_:
-  .zero 8
-
-  .type __hip_fatbin_,@object
+  .type __hip_fatbin,@object
   .section .hip_fatbin,"a",@progbits
-  .globl __hip_fatbin_
+  .globl __hip_fatbin
   .p2align 12
-__hip_fatbin_:
+__hip_fatbin:
   .incbin "offload_bundle.hipfb"


### PR DESCRIPTION
updating 16_assembly_to_executable/hip_obj_gen.mcin due to SWDEV-494206